### PR TITLE
feat: set reload default to true for index_repository

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -70,7 +70,7 @@ mcp = FastMCP(
 )        
 
 @mcp.tool()
-async def index_repository(ctx: Context, remote: str, repository: str, branch: str, reload: bool = False, notify: bool = False) -> str:
+async def index_repository(ctx: Context, remote: str, repository: str, branch: str, reload: bool = True, notify: bool = False) -> str:
     """Index a repository for code search and querying.
     
     This tool initiates the processing of a repository, making it available for future queries.
@@ -81,7 +81,8 @@ async def index_repository(ctx: Context, remote: str, repository: str, branch: s
         remote: The repository host, either "github" or "gitlab"
         repository: The repository in owner/repo format (e.g., "coleam00/mcp-mem0")
         branch: The branch to index (e.g., "main")
-        reload: Whether to force reprocessing of the repository (default: False)
+        reload: Whether to force reprocessing of the repository (default: True). 
+                When False, won't reprocess if previously indexed successfully.
         notify: Whether to send an email notification when indexing is complete (default: False)
     """
     try:

--- a/src/utils.py
+++ b/src/utils.py
@@ -78,7 +78,7 @@ class GreptileClient:
         remote: str, 
         repository: str, 
         branch: str, 
-        reload: bool = False, 
+        reload: bool = True, 
         notify: bool = False
     ) -> Dict[str, Any]:
         """
@@ -88,8 +88,9 @@ class GreptileClient:
             remote: The repository host, either "github" or "gitlab"
             repository: The repository in owner/repo format
             branch: The branch to index
-            reload: Whether to force reprocessing
-            notify: Whether to send an email notification
+            reload: Whether to force reprocessing (default: True).
+                   When False, won't reprocess if previously indexed successfully.
+            notify: Whether to send an email notification (default: False)
 
         Returns:
             The API response as a dictionary


### PR DESCRIPTION
## Summary

This PR updates the default value for the `reload` parameter in the `index_repository` function to match the Greptile API documentation.

## Changes

- Changed default value of `reload` parameter from `false` to `true` in both:
  - `GreptileClient.index_repository` method in `utils.py`
  - MCP tool `index_repository` function in `main.py`
- Updated documentation/docstrings to reflect the new default behavior
- Added clarification that `reload=false` won't reprocess if previously indexed successfully

## Rationale

The Greptile API documentation specifies that `reload` defaults to `true`. This change aligns our implementation with the API spec and ensures users get up-to-date repository information by default.

## Impact

- Better default behavior - users get fresh repository indexing by default
- Maintains backward compatibility - users can still set `reload=false` to skip re-indexing
- Saves time when users know a repository hasn't changed (using `reload=false`)

## Testing

The change is minimal and only affects default parameter values. Existing functionality remains unchanged.
