### PR TITLE
Implement Lazy Loading for Tool Listing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -26,41 +26,24 @@ load_dotenv()
 @dataclass
 class GreptileContext:
     """Context for the Greptile MCP server."""
-    greptile_client: GreptileClient  # The Greptile API client
-    initialized: bool = False  # Track if initialization is complete
     session_manager: Optional[SessionManager] = None  # Add session manager for conversation context
 
 @asynccontextmanager
 async def greptile_lifespan(server: FastMCP) -> AsyncIterator[GreptileContext]:
     """
-    Manages the Greptile client lifecycle and session/conv context.
+    Manages the session/conv context (no Greptile client, so tool listing does not require config).
 
     Args:
         server: The FastMCP server instance
 
     Yields:
-        GreptileContext: The context containing the Greptile client and session manager
+        GreptileContext: The context containing the session manager
     """
-    greptile_client = get_greptile_client()
     session_manager = SessionManager()
-    context = GreptileContext(greptile_client=greptile_client, initialized=False, session_manager=session_manager)
+    context = GreptileContext(session_manager=session_manager)
+    yield context
 
-    try:
-        print("Initializing Greptile client...")
-        try:
-            await asyncio.sleep(0.5)
-            context.initialized = True
-            print("Greptile client successfully initialized")
-        except Exception as e:
-            print(f"Error during Greptile client initialization: {e}")
-            raise
-
-        yield context
-    finally:
-        await greptile_client.aclose()
-        print("Greptile client closed.")
-
-# Initialize FastMCP server with the Greptile client and session manager as context
+# Initialize FastMCP server with the session manager as context
 mcp = FastMCP(
     "mcp-greptile",
     description="MCP server for code search and querying with Greptile API",
@@ -72,12 +55,12 @@ mcp = FastMCP(
 @mcp.tool()
 async def index_repository(ctx: Context, remote: str, repository: str, branch: str, reload: bool = False, notify: bool = False) -> str:
     """Index a repository for code search and querying.
-    
+
     This tool initiates the processing of a repository, making it available for future queries.
     A repository must be indexed before it can be queried or searched.
-    
+
     Args:
-        ctx: The MCP server provided context which includes the Greptile client
+        ctx: The MCP server provided context
         remote: The repository host, either "github" or "gitlab"
         repository: The repository in owner/repo format (e.g., "coleam00/mcp-mem0")
         branch: The branch to index (e.g., "main")
@@ -85,17 +68,10 @@ async def index_repository(ctx: Context, remote: str, repository: str, branch: s
         notify: Whether to send an email notification when indexing is complete (default: False)
     """
     try:
-        greptile_context = ctx.request_context.lifespan_context
-        
-        # Check if initialization is complete
-        if not getattr(greptile_context, 'initialized', False):
-            return json.dumps({
-                "error": "Server initialization is not complete. Please try again in a moment.",
-                "status": "initializing"
-            }, indent=2)
-            
-        greptile_client = greptile_context.greptile_client
+        from src.utils import get_greptile_client
+        greptile_client = get_greptile_client()
         result = await greptile_client.index_repository(remote, repository, branch, reload, notify)
+        await greptile_client.aclose()
         return json.dumps(result, indent=2)
     except Exception as e:
         return f"Error indexing repository: {str(e)}"
@@ -131,14 +107,9 @@ async def query_repository(
         - For non-streaming: formatted JSON string (single result).
     """
     try:
+        from src.utils import get_greptile_client
+        greptile_client = get_greptile_client()
         greptile_context = ctx.request_context.lifespan_context
-        if not getattr(greptile_context, 'initialized', False):
-            return json.dumps({
-                "error": "Server initialization is not complete. Please try again in a moment.",
-                "status": "initializing"
-            }, indent=2)
-
-        greptile_client = greptile_context.greptile_client
         session_manager: SessionManager = greptile_context.session_manager
 
         # Session logic
@@ -159,25 +130,22 @@ async def query_repository(
                 async for chunk in greptile_client.stream_query_repositories(
                     messages, repositories, session_id=sid, genius=genius, timeout=timeout
                 ):
-                    # Optionally, add chunk/response to session history (system/assistant)
-                    # If Greptile API returns role/content, could append to session
                     yield json.dumps(chunk)
+                await greptile_client.aclose()
             return streaming_gen()
 
         # Non-streaming query; get response fully then append to session history
         result = await greptile_client.query_repositories(
             messages, repositories, session_id=sid, stream=False, genius=genius, timeout=timeout
         )
+        await greptile_client.aclose()
 
         # Persist new assistant/content response in session history if return has role/content fields
         if "messages" in result:
-            # If API returns messages array, update session
             await session_manager.set_history(sid, result["messages"])
         elif "output" in result:
-            # If API returns one assistant message, append it
             await session_manager.append_message(sid, {"role": "assistant", "content": result["output"]})
 
-        # Attach the session_id for client reference
         result["_session_id"] = sid
         return json.dumps(result, indent=2)
     except Exception as e:
@@ -186,30 +154,23 @@ async def query_repository(
 @mcp.tool()
 async def search_repository(ctx: Context, query: str, repositories: list, session_id: str = None, genius: bool = True) -> str:
     """Search repositories for relevant files without generating a full answer.
-    
+
     This tool returns a list of relevant files based on a query without generating
     a complete answer. The repositories must have been indexed first.
-    
+
     Args:
-        ctx: The MCP server provided context which includes the Greptile client
+        ctx: The MCP server provided context
         query: The natural language query about the codebase
         repositories: List of repositories to search, each with format {"remote": "github", "repository": "owner/repo", "branch": "main"}
         session_id: Optional session ID for continuing a conversation
         genius: Whether to use the enhanced search capabilities (default: True)
     """
     try:
-        greptile_context = ctx.request_context.lifespan_context
-        
-        # Check if initialization is complete
-        if not getattr(greptile_context, 'initialized', False):
-            return json.dumps({
-                "error": "Server initialization is not complete. Please try again in a moment.",
-                "status": "initializing"
-            }, indent=2)
-            
-        greptile_client = greptile_context.greptile_client
+        from src.utils import get_greptile_client
+        greptile_client = get_greptile_client()
         messages = [{"role": "user", "content": query}]
         result = await greptile_client.search_repositories(messages, repositories, session_id, genius)
+        await greptile_client.aclose()
         return json.dumps(result, indent=2)
     except Exception as e:
         return f"Error searching repositories: {str(e)}"
@@ -217,24 +178,24 @@ async def search_repository(ctx: Context, query: str, repositories: list, sessio
 @mcp.tool()
 async def get_repository_info(ctx: Context, remote: str, repository: str, branch: str) -> str:
     """Get information about an indexed repository.
-    
+
     This tool retrieves information about a specific repository that has been indexed,
     including its status and other metadata.
-    
+
     The tool handles proper URL encoding internally to ensure repository identifiers
     with special characters (like '/') are correctly processed.
-    
+
     Args:
-        ctx: The MCP server provided context which includes the Greptile client
+        ctx: The MCP server provided context
         remote: The repository host, either "github" or "gitlab"
         repository: The repository in owner/repo format (e.g., "coleam00/mcp-mem0")
         branch: The branch that was indexed (e.g., "main")
-        
+
     Returns:
         A JSON string containing repository information such as status, last indexed time,
         and other metadata. If the repository is still being indexed, the status will 
         indicate the current progress.
-        
+
     Example Response:
         {
           "id": "github:main:owner/repo",
@@ -248,18 +209,11 @@ async def get_repository_info(ctx: Context, remote: str, repository: str, branch
         }
     """
     try:
-        greptile_context = ctx.request_context.lifespan_context
-        
-        # Check if initialization is complete
-        if not getattr(greptile_context, 'initialized', False):
-            return json.dumps({
-                "error": "Server initialization is not complete. Please try again in a moment.",
-                "status": "initializing"
-            }, indent=2)
-            
-        greptile_client = greptile_context.greptile_client
+        from src.utils import get_greptile_client
+        greptile_client = get_greptile_client()
         repository_id = f"{remote}:{branch}:{repository}"
         result = await greptile_client.get_repository_info(repository_id)
+        await greptile_client.aclose()
         return json.dumps(result, indent=2)
     except Exception as e:
         return f"Error getting repository info: {str(e)}"


### PR DESCRIPTION
This pull request modifies the Greptile MCP server to support lazy loading of the Greptile client, ensuring that tool listing does not require any API keys or configurations. The `GreptileContext` no longer holds the Greptile client or an initialization flag, which allows the server to list tools without needing authentication upfront. Instead, the Greptile client is instantiated only when a tool is called, improving the server's usability and compliance with the requirement that tool listing should not depend on user-provided configurations. Key changes include:

- Removed the Greptile client from the `GreptileContext`.
- Updated the `greptile_lifespan` function to yield a context with only the session manager.
- Adjusted tool functions to import and instantiate the Greptile client as needed, ensuring it is only authenticated during tool execution.

---

> This pull request was co-created with Cosine Genie

Original Task: [greptile-mcp/84vbu8j8xa9c](https://cosine.sh/dbesqkwbz6a0/greptile-mcp/task/84vbu8j8xa9c)
Author: Freddy Williams
