### PR TITLE
Enhance Health Check Endpoint to Report Missing Environment Variables

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -266,16 +266,27 @@ export default {
 
     // Health check endpoint
     if (path === '/' || path === '/health') {
+      let status = 'healthy';
+      const missingEnv: string[] = [];
+      if (!env.GREPTILE_API_KEY) missingEnv.push('GREPTILE_API_KEY');
+      if (!env.GITHUB_TOKEN) missingEnv.push('GITHUB_TOKEN');
+
+      if (missingEnv.length > 0) {
+        status = 'degraded';
+      }
+
       const healthData = {
-        status: 'healthy',
+        status,
         service: 'greptile-mcp-server',
         version: '1.0.0',
         deployment: 'cloudflare-workers',
         runtime: 'typescript',
+        missingEnv: missingEnv.length ? missingEnv : undefined,
+        timestamp: new Date().toISOString(),
       };
 
       return new Response(JSON.stringify(healthData), {
-        status: 200,
+        status: status === 'healthy' ? 200 : 500,
         headers: createCORSHeaders(),
       });
     }


### PR DESCRIPTION
This PR modifies the health check endpoint in `src/worker.ts` to return a status of 'degraded' if required environment variables are missing. The following changes were made:

- Added logic to check for the presence of `GREPTILE_API_KEY` and `GITHUB_TOKEN`.
- If any required environment variables are missing, the status in the response is set to 'degraded' and a list of missing variables is included in the response payload.
- The HTTP status code returned is now 500 if the service is degraded instead of 200.

These enhancements provide clearer insight into the service's health by explicitly stating which environment variables are missing, allowing for quicker diagnosis and resolution of issues.

---

> This pull request was co-created with Cosine Genie

Original Task: [greptile-mcp/v80b3qahurws](https://cosine.sh/7w0g3r7rjekw/greptile-mcp/task/v80b3qahurws)
Author: ashmom12
