### PR TITLE
Troubleshoot Docker image build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "greptile-mcp-server"
+version = "2.0.0"
+description = "Modern Greptile MCP Server using FastMCP 2.0"
+readme = "README.md"
+authors = [
+    {name = "FastMCP Team", email = "team@fastmcp.com"}
+]
+license = {text = "MIT"}
+requires-python = ">=3.11"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "fastmcp>=2.10.0",
+    "httpx>=0.27.0",
+    "python-dotenv>=1.0.0",
+    "uvloop>=0.19.0; sys_platform != 'win32'",
+]
+
+[project.urls]
+Homepage = "https://github.com/fastmcp/greptile-mcp-server"
+Repository = "https://github.com/fastmcp/greptile-mcp-server"
+Issues = "https://github.com/fastmcp/greptile-mcp-server/issues"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["src*"]
+
+[tool.setuptools.package-dir]
+"" = "."


### PR DESCRIPTION
Add `pyproject.toml` to resolve `pip install -e .` error in Docker builds.